### PR TITLE
fix: adapted unit tests with new cacheKey parameter that was included on IsNotificationAllowed and UpdateNotificationLimit

### DIFF
--- a/NotificationService.Test/UseCases/RateLimitProcessorTests.cs
+++ b/NotificationService.Test/UseCases/RateLimitProcessorTests.cs
@@ -39,7 +39,7 @@ public class RateLimitProcessorTests
             };
 
             // Act
-            var result = _rateLimitProcessor.IsNotificationAllowed(notification);
+            var result = _rateLimitProcessor.IsNotificationAllowed(notification, $"{notification.Recipient.EmailAdress}:{notification.Type.ToString()}");
 
             // Assert
             Assert.True(result);
@@ -59,7 +59,7 @@ public class RateLimitProcessorTests
                              .Returns(1); // Existing count is below the limit
 
             // Act
-            var result = _rateLimitProcessor.IsNotificationAllowed(notification);
+            var result = _rateLimitProcessor.IsNotificationAllowed(notification, $"{notification.Recipient.EmailAdress}:{notification.Type.ToString()}");
 
             // Assert
             Assert.True(result);
@@ -79,7 +79,7 @@ public class RateLimitProcessorTests
                              .Returns(3); // Existing count equals the limit
 
             // Act
-            var result = _rateLimitProcessor.IsNotificationAllowed(notification);
+            var result = _rateLimitProcessor.IsNotificationAllowed(notification, $"{notification.Recipient.EmailAdress}:{notification.Type.ToString()}");
 
             // Assert
             Assert.False(result);
@@ -99,7 +99,7 @@ public class RateLimitProcessorTests
                              .Returns(3); // Existing count is 3
 
             // Act
-            var result = _rateLimitProcessor.UpdateNotificationLimit(notification);
+            var result = _rateLimitProcessor.UpdateNotificationLimit(notification, $"{notification.Recipient.EmailAdress}:{notification.Type.ToString()}");
 
             // Assert
             _mockCacheService.Verify(cache => cache.SetData("test@example.com:News", 4, It.IsAny<TimeSpan>()), Times.Once);

--- a/NotificationService.Test/UseCases/Strategies/RateLimitedNotificationProcessorTests.cs
+++ b/NotificationService.Test/UseCases/Strategies/RateLimitedNotificationProcessorTests.cs
@@ -34,7 +34,7 @@ public class RateLimitedNotificationProcessorTests
                 Recipient = new Recipient { EmailAdress = "test@example.com" }
             };
 
-            _mockRateLimitProcessor.Setup(r => r.IsNotificationAllowed(notification))
+            _mockRateLimitProcessor.Setup(r => r.IsNotificationAllowed(notification, $"{notification.Recipient.EmailAdress}:{notification.Type.ToString()}"))
                                    .Returns(true);
 
             // Act
@@ -42,7 +42,7 @@ public class RateLimitedNotificationProcessorTests
 
             // Assert
             Assert.True(result.IsSuccess);
-            _mockRateLimitProcessor.Verify(r => r.UpdateNotificationLimit(notification), Times.Once);
+            _mockRateLimitProcessor.Verify(r => r.UpdateNotificationLimit(notification, $"{notification.Recipient.EmailAdress}:{notification.Type.ToString()}"), Times.Once);
         }
 
         [Fact]
@@ -55,7 +55,7 @@ public class RateLimitedNotificationProcessorTests
                 Recipient = new Recipient { EmailAdress = "test@example.com" }
             };
 
-            _mockRateLimitProcessor.Setup(r => r.IsNotificationAllowed(notification))
+            _mockRateLimitProcessor.Setup(r => r.IsNotificationAllowed(notification, $"{notification.Recipient.EmailAdress}:{notification.Type.ToString()}"))
                                    .Returns(false);
 
             // Act
@@ -64,6 +64,6 @@ public class RateLimitedNotificationProcessorTests
             // Assert
             Assert.False(result.IsSuccess);
             Assert.Equal("RateLimit.Exceeded", result.Error.Code);
-            _mockRateLimitProcessor.Verify(r => r.UpdateNotificationLimit(notification), Times.Never);
+            _mockRateLimitProcessor.Verify(r => r.UpdateNotificationLimit(notification, $"{notification.Recipient.EmailAdress}:{notification.Type.ToString()}"), Times.Never);
         }
 }


### PR DESCRIPTION
fix: adapted unit tests with new cacheKey parameter that was included on IsNotificationAllowed and UpdateNotificationLimit